### PR TITLE
CTECH-1576: Fixes docker-compose for access tokens

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -6,6 +6,4 @@ WORKDIR /usr/src
 COPY pom.xml /usr/src/
 RUN mvn install
 
-ENV FBN_ACCESS_API_URL ${FBN_ACCESS_API_URL}
-
 ENTRYPOINT mvn -e -fae test

--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - FBN_CLIENT_ID
       - FBN_CLIENT_SECRET
       - FBN_APP_NAME
-      - FBN_ACCESS_API_URL
+      - FBN_ACCESS_API_URL=${FBN_BASE_API_URL}/access
+      - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Updates the docker-compose file to enable testing with personal access tokens.
